### PR TITLE
- Changed git submodule from file to https://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "equibit-core"]
 	path = equibit-core
-	url = ../equibit-core.git
-	branch = testnet
+	url = https://github.com/Equibit/equibit-core
+	branch = dev


### PR DESCRIPTION
The URL for the submodule was incorrect as it looks like it was a local directory used for development.

I changed it to https://github.com/Equibit/equibit-core, not sure if git@github.com/Equibit/equibit-core would be better, as long as it works... it's your call.

I changed the branch to dev from testnet because I think the commit that's referenced in the submodule is on the dev branch and not the testnet one.