### PR TITLE
- Updated core to v0.02.08, updated tag in rebuild.sh

### DIFF
--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,1 +1,1 @@
-docker image build -t macterra/eqb-testnet:v02.01 .
+docker image build -t macterra/eqb-testnet:v02.08 .


### PR DESCRIPTION
This is to update the docker container to v02.08, built with the newly tagged equibit-core